### PR TITLE
[TEST] Share Unit Test 작성

### DIFF
--- a/.gradle/buildOutputCleanup/cache.properties
+++ b/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Thu Aug 22 14:59:41 KST 2024
+#Thu Aug 22 15:24:30 KST 2024
 gradle.version=8.5

--- a/src/main/java/org/c4marathon/assignment/share/application/service/DeleteFileToSharedFolderService.java
+++ b/src/main/java/org/c4marathon/assignment/share/application/service/DeleteFileToSharedFolderService.java
@@ -27,5 +27,4 @@ public class DeleteFileToSharedFolderService implements DeleteFileToSharedFolder
         deleteFileUseCase.deleteFile(share.getUser(), fileId);
     }
 
-
 }

--- a/src/main/java/org/c4marathon/assignment/share/application/service/UploadFileToSharedFolderService.java
+++ b/src/main/java/org/c4marathon/assignment/share/application/service/UploadFileToSharedFolderService.java
@@ -23,7 +23,8 @@ public class UploadFileToSharedFolderService implements UploadFileToSharedFolder
     public void uploadFileToSharedFolder(String uuid, String fileName, byte[] file) {
         Share share = getShareUseCase.getShare(uuid);
         shareValidator.validateFolderShare(share);
-        uploadFileUseCase.uploadFile(share.getUser(), fileName, share.getFolder().getId(), file);
+        Long folderId = share.getFolder() == null ? null : share.getFolder().getId();
+        uploadFileUseCase.uploadFile(share.getUser(), fileName, folderId, file);
     }
 
 }

--- a/src/test/java/org/c4marathon/assignment/file/application/service/component/FileFactoryTest.java
+++ b/src/test/java/org/c4marathon/assignment/file/application/service/component/FileFactoryTest.java
@@ -1,7 +1,7 @@
 package org.c4marathon.assignment.file.application.service.component;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.mockito.MockedStatic;
 
 import java.io.File;
 import java.io.IOException;
@@ -9,12 +9,23 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class FileFactoryTest {
 
     private final FileFactory fileFactory = new FileFactory();
+
+    private static MockedStatic<Files> files;
+
+    @BeforeAll
+    public static void beforeAll() {
+        files = mockStatic(Files.class);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        files.close();
+    }
 
     @Test
     @DisplayName("createPath() 메서드는 주어진 경로를 Path 객체로 변환한다.")
@@ -50,7 +61,6 @@ class FileFactoryTest {
         Path target = Path.of("src/test/resources/test - Copy.txt");
 
         // mock
-        mockStatic(Files.class);
         when(Files.copy(origin, target)).thenReturn(target);
 
         // when
@@ -65,9 +75,6 @@ class FileFactoryTest {
     void deleteFile() throws IOException {
         // given
         Path path = Path.of("src/test/resources/test.txt");
-
-        // mock
-        mockStatic(Files.class);
 
         // when & then
         assertDoesNotThrow(() -> fileFactory.deleteFile(path));

--- a/src/test/java/org/c4marathon/assignment/share/application/service/DeleteFileToSharedFolderServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/DeleteFileToSharedFolderServiceTest.java
@@ -1,0 +1,45 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.file.application.port.in.DeleteFileUseCase;
+import org.c4marathon.assignment.share.application.port.in.GetShareUseCase;
+import org.c4marathon.assignment.share.domain.entity.Share;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class DeleteFileToSharedFolderServiceTest {
+
+    @Mock
+    private GetShareUseCase getShareUseCase;
+
+    @Mock
+    private ShareValidator shareValidator;
+
+    @Mock
+    private DeleteFileUseCase deleteFileUseCase;
+
+    @InjectMocks
+    private DeleteFileToSharedFolderService deleteFileToSharedFolderService;
+
+    @Test
+    @DisplayName("공유받은 폴더 내부의 파일을 누구나 삭제할 수 있다.")
+    void deleteFileToSharedFolder() {
+        // given
+        String uuid = "uuid";
+        Long fileId = 1L;
+        Share share = mock(Share.class);
+        when(getShareUseCase.getShare(uuid)).thenReturn(share);
+
+        // when & then
+        assertDoesNotThrow(() -> deleteFileToSharedFolderService.deleteFileToSharedFolder(uuid, fileId));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/DownloadFileFromSharedFolderServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/DownloadFileFromSharedFolderServiceTest.java
@@ -1,0 +1,51 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.file.application.port.in.DownloadFileUseCase;
+import org.c4marathon.assignment.share.application.port.in.GetShareUseCase;
+import org.c4marathon.assignment.share.domain.entity.Share;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class DownloadFileFromSharedFolderServiceTest {
+
+    @Mock
+    private GetShareUseCase getShareUseCase;
+
+    @Mock
+    private ShareValidator shareValidator;
+
+    @Mock
+    private DownloadFileUseCase downloadFileUseCase;
+
+    @InjectMocks
+    private DownloadFileFromSharedFolderService downloadFileFromSharedFolderService;
+
+    @Test
+    @DisplayName("공유받은 폴더 내부에 있는 파일을 누구나 다운로드 할 수 있다.")
+    void downloadFileFromSharedFolder() {
+        // given
+        String uuid = "uuid";
+        String fileDownloadPath = "file/download/path";
+        User user = mock(User.class);
+        Share share = mock(Share.class);
+        when(getShareUseCase.getShare(uuid)).thenReturn(share);
+        when(share.getUser()).thenReturn(user);
+        when(downloadFileUseCase.downloadFile(share.getUser(), 1L)).thenReturn(fileDownloadPath);
+
+        // when
+        String result = downloadFileFromSharedFolderService.downloadFileFromSharedFolder(uuid, 1L);
+
+        // then
+        assertEquals(fileDownloadPath, result);
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/DownloadSharedFileServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/DownloadSharedFileServiceTest.java
@@ -1,0 +1,68 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.file.application.service.FileSearchService;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.global.exception.customs.ExpiredLinkException;
+import org.c4marathon.assignment.share.application.port.out.ShareCommandPort;
+import org.c4marathon.assignment.share.domain.entity.Share;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class DownloadSharedFileServiceTest {
+
+    @Mock
+    private ShareCommandPort shareCommandPort;
+
+    @Mock
+    private FileSearchService fileSearchService;
+
+    @Mock
+    private SearchShareService searchShareService;
+
+    @InjectMocks
+    private DownloadSharedFileService downloadSharedFileService;
+
+    @Test
+    @DisplayName("만료되지 않은 다운로드 링크의 uuid을 이용하여 공유된 파일을 다운로드 받을 수 있다.")
+    void downloadSharedFile() {
+        // given
+        String uuid = "uuid";
+        User user = mock(User.class);
+        Share share = mock(Share.class);
+        File file = mock(File.class);
+        when(searchShareService.getShare(uuid)).thenReturn(share);
+        when(share.isExpired()).thenReturn(false);
+        when(share.getFile()).thenReturn(file);
+        when(file.getId()).thenReturn(1L);
+        when(share.getUser()).thenReturn(user);
+        when(fileSearchService.getFile(share.getUser(), share.getFile().getId())).thenReturn(file);
+        when(file.getPath()).thenReturn("path");
+
+        // when & then
+        assertDoesNotThrow(() -> downloadSharedFileService.downloadSharedFile(uuid));
+    }
+
+    @Test
+    @DisplayName("만료된 다운로드 링크의 uuid을 이용하여 공유된 파일을 다운로드 받으려하면 ExpiredLinkException을 던진다.")
+    void downloadSharedFileExpiredLink() {
+        // given
+        String uuid = "uuid";
+        Share share = mock(Share.class);
+        when(searchShareService.getShare(uuid)).thenReturn(share);
+        when(share.isExpired()).thenReturn(true);
+
+        // when & then
+        assertThrows(ExpiredLinkException.class, () -> downloadSharedFileService.downloadSharedFile(uuid));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/PublishDownloadFileLinkServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/PublishDownloadFileLinkServiceTest.java
@@ -1,0 +1,46 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.file.application.service.FileSearchService;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.share.application.port.out.ShareCommandPort;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class PublishDownloadFileLinkServiceTest {
+
+    @Mock
+    private ShareCommandPort shareCommandPort;
+
+    @Mock
+    private FileSearchService fileSearchService;
+
+    @InjectMocks
+    private PublishDownloadFileLinkService publishDownloadFileLinkService;
+
+    @Test
+    @DisplayName("파일 ID를 이용하여 다운로드 링크를 생성할 수 있다.")
+    void publishDownloadFileLink() {
+        // given
+        User user = mock(User.class);
+        File file = mock(File.class);
+        String expectedSubLink = "/api/v1/share/files/download/";
+        when(fileSearchService.getFile(user, 1L)).thenReturn(file);
+
+        // when
+        String result = publishDownloadFileLinkService.publishDownloadFileLink(user, 1L);
+
+        // then
+        assertTrue(result.contains(expectedSubLink));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/PublishShareFolderServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/PublishShareFolderServiceTest.java
@@ -1,0 +1,62 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.folder.application.service.FolderSearchService;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.share.application.port.out.ShareCommandPort;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class PublishShareFolderServiceTest {
+
+    @Mock
+    private ShareCommandPort shareCommandPort;
+
+    @Mock
+    private FolderSearchService folderSearchService;
+
+    @InjectMocks
+    private PublishShareFolderService publishShareFolderService;
+
+    private static MockedStatic<LocalDateTime> localDateTimeMockedStatic;
+
+    private static LocalDateTime now = LocalDateTime.of(2021, 1, 1, 0, 0);
+
+    @BeforeAll
+    public static void beforeAll() {
+        localDateTimeMockedStatic = mockStatic(LocalDateTime.class);
+        localDateTimeMockedStatic.when(LocalDateTime::now).thenReturn(now);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        localDateTimeMockedStatic.close();
+    }
+
+    @Test
+    @DisplayName("folderId를 이용하여 Share를 생성할 수 있다.")
+    void publishShareFolder() {
+        // given
+        User user = mock(User.class);
+        Folder folder = mock(Folder.class);
+        when(folderSearchService.findById(user, 1L)).thenReturn(folder);
+
+        // when & then
+        assertDoesNotThrow(() -> publishShareFolderService.publishShareFolder(user, 1L));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/SearchShareServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/SearchShareServiceTest.java
@@ -1,0 +1,52 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.global.exception.customs.NotFoundException;
+import org.c4marathon.assignment.share.application.port.out.ShareQueryPort;
+import org.c4marathon.assignment.share.domain.entity.Share;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class SearchShareServiceTest {
+
+    @Mock
+    private ShareQueryPort shareQueryPort;
+
+    @InjectMocks
+    private SearchShareService searchShareService;
+
+    @Test
+    @DisplayName("uuid를 이용하여 Share를 찾을 수 있다.")
+    void getShareByUUID() {
+        // given
+        Share share = mock(Share.class);
+        when(shareQueryPort.findById(anyString())).thenReturn(Optional.of(share));
+
+        // when
+        Share result = searchShareService.getShare("uuid");
+
+        // then
+        assertEquals(result, share);
+    }
+
+    @Test
+    @DisplayName("일치하는 uuid의 Share가 없다면 NotFoundException을 던진다.")
+    void uuidNotFoundException() {
+        // given
+        when(shareQueryPort.findById(anyString())).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(NotFoundException.class, () -> searchShareService.getShare("uuid"));
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/ShareValidatorTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/ShareValidatorTest.java
@@ -1,0 +1,137 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.file.application.service.FileSearchService;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.global.exception.customs.ExpiredLinkException;
+import org.c4marathon.assignment.share.application.port.out.ShareCommandPort;
+import org.c4marathon.assignment.share.domain.entity.Share;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class ShareValidatorTest {
+
+    @Mock
+    private ShareCommandPort shareCommandPort;
+
+    @Mock
+    private FileSearchService fileSearchService;
+
+    @InjectMocks
+    private ShareValidator shareValidator;
+
+    @Test
+    @DisplayName("Share가 폴더에 대한 공유가 아니라면 IllegalArgumentException을 던진다.")
+    void validateIsFolder() {
+        // given
+        Share share = mock(Share.class);
+        when(share.getIsFolder()).thenReturn(false);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> shareValidator.validateFolderShare(share));
+    }
+
+    @Test
+    @DisplayName("Share가 폴더에 대한 공유이지만 만료되었다면 ExpiredLinkException을 던지고 Share를 삭제한다.")
+    void validateIsFolderButExpired() {
+        // given
+        Share share = mock(Share.class);
+        when(share.getIsFolder()).thenReturn(true);
+        when(share.isExpired()).thenReturn(true);
+
+        // when & then
+        assertThrows(ExpiredLinkException.class, () -> shareValidator.validateFolderShare(share));
+        verify(shareCommandPort, times(1)).delete(share);
+    }
+
+    @Test
+    @DisplayName("Share가 폴더에 대한 공유이고 만료되지 않았다면 아무런 예외를 던지지 않는다.")
+    void validateIsFolderAndNotExpired() {
+        // given
+        Share share = mock(Share.class);
+        when(share.getIsFolder()).thenReturn(true);
+        when(share.isExpired()).thenReturn(false);
+
+        // when & then
+        assertDoesNotThrow(() -> shareValidator.validateFolderShare(share));
+    }
+
+    @Test
+    @DisplayName("파일이 공유받은 폴더에 속하지 않는다면 IllegalArgumentException을 던진다.")
+    void validateIsInSharedFolder() {
+        // given
+        Long fileId = 1L;
+        Share share = mock(Share.class);
+        File file = mock(File.class);
+        Folder folder1 = mock(Folder.class);
+        Folder folder2 = mock(Folder.class);
+        when(fileSearchService.getFile(share.getUser(), fileId)).thenReturn(file);
+        when(share.getFolder()).thenReturn(folder1);
+        when(folder1.getId()).thenReturn(1L);
+        when(file.getFolder()).thenReturn(folder2);
+        when(folder2.getId()).thenReturn(2L);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> shareValidator.validateIsInSharedFolder(share, fileId));
+    }
+
+    @Test
+    @DisplayName("파일이 공유받은 폴더에 속하지 않는다면 IllegalArgumentException을 던진다. (공유 폴더가 루트 폴더인 경우)")
+    void validateIsInSharedFolderCaseRootFolderButFileIsNotInRoot() {
+        // given
+        Long fileId = 1L;
+        Share share = mock(Share.class);
+        File file = mock(File.class);
+        Folder folder = mock(Folder.class);
+        when(fileSearchService.getFile(share.getUser(), fileId)).thenReturn(file);
+        when(share.getFolder()).thenReturn(null);
+        when(file.getFolder()).thenReturn(folder);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> shareValidator.validateIsInSharedFolder(share, fileId));
+    }
+
+    @Test
+    @DisplayName("파일이 공유받은 폴더에 속하지 않는다면 IllegalArgumentException을 던진다. (공유 폴더가 루트 폴더가 아니고 파일이 루트 폴더에 있는 경우)")
+    void validateIsInSharedFolderCaseRootFolderButShareFolderIsNotRoot() {
+        // given
+        Long fileId = 1L;
+        Share share = mock(Share.class);
+        File file = mock(File.class);
+        Folder folder = mock(Folder.class);
+        when(fileSearchService.getFile(share.getUser(), fileId)).thenReturn(file);
+        when(share.getFolder()).thenReturn(folder);
+        when(file.getFolder()).thenReturn(null);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> shareValidator.validateIsInSharedFolder(share, fileId));
+    }
+
+
+    @Test
+    @DisplayName("파일이 공유받은 폴더에 속한다면 아무런 예외를 던지지 않는다.")
+    void validateIsInSharedFolderValid() {
+        // given
+        Long fileId = 1L;
+        Share share = mock(Share.class);
+        File file = mock(File.class);
+        Folder folder1 = mock(Folder.class);
+        Folder folder2 = mock(Folder.class);
+        when(fileSearchService.getFile(share.getUser(), fileId)).thenReturn(file);
+        when(share.getFolder()).thenReturn(folder1);
+        when(folder1.getId()).thenReturn(1L);
+        when(file.getFolder()).thenReturn(folder2);
+        when(folder2.getId()).thenReturn(1L);
+
+        // when & then
+        assertDoesNotThrow(() -> shareValidator.validateIsInSharedFolder(share, fileId));
+    }
+}

--- a/src/test/java/org/c4marathon/assignment/share/application/service/UploadFileToSharedFolderServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/application/service/UploadFileToSharedFolderServiceTest.java
@@ -1,0 +1,56 @@
+package org.c4marathon.assignment.share.application.service;
+
+import org.c4marathon.assignment.file.application.port.in.UploadFileUseCase;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.share.application.port.in.GetShareUseCase;
+import org.c4marathon.assignment.share.domain.entity.Share;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.c4marathon.assignment.tools.TestTool.createFile;
+import static org.c4marathon.assignment.tools.TestTool.createUser;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class UploadFileToSharedFolderServiceTest {
+
+    @Mock
+    private GetShareUseCase getShareUseCase;
+
+    @Mock
+    private ShareValidator shareValidator;
+
+    @Mock
+    private UploadFileUseCase uploadFileUseCase;
+
+    @InjectMocks
+    private UploadFileToSharedFolderService uploadFileToSharedFolderService;
+
+    @Test
+    @DisplayName("공유받은 폴더의 UUID를 이용하여 누구나 파일을 업로드할 수 있다.")
+    void uploadFileToSharedFolder() {
+        // given
+        User user = createUser();
+        File file = createFile(user);
+        String uuid = UUID.randomUUID().toString();
+        LocalDateTime expiredAt = LocalDateTime.now().plusDays(1);
+        Share share = Share.of(uuid, user, file, null, null, expiredAt);
+        byte[] bytes = "Hello, World!".getBytes();
+
+        // mock
+        when(getShareUseCase.getShare(uuid)).thenReturn(share);
+
+        // when & then
+        assertDoesNotThrow(() -> uploadFileToSharedFolderService.uploadFileToSharedFolder(uuid, "file.txt", bytes));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/share/domain/entity/ShareTest.java
+++ b/src/test/java/org/c4marathon/assignment/share/domain/entity/ShareTest.java
@@ -1,0 +1,55 @@
+package org.c4marathon.assignment.share.domain.entity;
+
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.c4marathon.assignment.tools.TestTool.createFile;
+import static org.c4marathon.assignment.tools.TestTool.createUser;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ShareTest {
+
+    @Test
+    @DisplayName("isExpired()는 공유 링크가 만료됐다면 True를 반환한다.")
+    void isExpiredReturnTrue() {
+        // given
+        User user = createUser();
+        File file = createFile(user);
+        Share share = createFileShare(user, file, LocalDateTime.now().minusDays(1));
+
+        // when
+        boolean isExpired = share.isExpired();
+
+        // then
+        assertTrue(isExpired);
+    }
+
+    @Test
+    @DisplayName("isExpired()는 공유 링크가 만료되지 않았다면 False를 반환한다.")
+    void isExpiredReturnFalse() {
+        // given
+        User user = createUser();
+        File file = createFile(user);
+        Share share = createFileShare(user, file, LocalDateTime.now().plusDays(1));
+
+        // when
+        boolean isExpired = share.isExpired();
+
+        // then
+        assertFalse(isExpired);
+    }
+
+    public static Share createFileShare(User user, File file, LocalDateTime expiredAt) {
+        return Share.of("1", user, file, null, false, expiredAt);
+    }
+
+    public static Share createFolderShare(User user, Folder folder, LocalDateTime expiredAt) {
+        return Share.of("1", user, null, folder, true, expiredAt);
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/thumbnail/application/service/component/WriteImageTest.java
+++ b/src/test/java/org/c4marathon/assignment/thumbnail/application/service/component/WriteImageTest.java
@@ -1,15 +1,19 @@
 package org.c4marathon.assignment.thumbnail.application.service.component;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -20,6 +24,18 @@ class WriteImageTest {
     @InjectMocks
     private WriteImage writeImage;
 
+    private static MockedStatic<ImageIO> imageIO;
+
+    @BeforeAll
+    public static void beforeAll() {
+        imageIO = mockStatic(ImageIO.class);
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        imageIO.close();
+    }
+
     @Test
     @DisplayName("writeImage()는 이미지를 파일 시스템에 저장한다.")
     void writeImage() throws IOException {
@@ -29,7 +45,6 @@ class WriteImageTest {
         // mock
         BufferedImage mockedBufferedImage = mock(BufferedImage.class);
         File mockedFile = mock(File.class);
-        mockStatic(ImageIO.class);
         when(ImageIO.write(mockedBufferedImage, formatName, mockedFile)).thenReturn(true);
 
         // when

--- a/src/test/java/org/c4marathon/assignment/tools/TestTool.java
+++ b/src/test/java/org/c4marathon/assignment/tools/TestTool.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.tools;
 
 import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.share.domain.entity.Share;
 import org.c4marathon.assignment.user.domain.entity.User;
 
 public class TestTool {


### PR DESCRIPTION
## Share 테스트 목록
- isExpired()는 공유 링크가 만료됐다면 True를 반환한다.
- isExpired()는 공유 링크가 만료되지 않았다면 False를 반환한다.

## UploadFileToSharedFolderService 테스트 목록
- 공유받은 폴더의 UUID를 이용하여 누구나 파일을 업로드할 수 있다.

## ShareValidator 테스트 목록
- Share가 폴더에 대한 공유가 아니라면 IllegalArgumentException을 던진다.
- Share가 폴더에 대한 공유이지만 만료되었다면 ExpiredLinkException을 던지고 Share를 삭제한다.
- Share가 폴더에 대한 공유이고 만료되지 않았다면 아무런 예외를 던지지 않는다.
- 파일이 공유받은 폴더에 속하지 않는다면 IllegalArgumentException을 던진다.
- 파일이 공유받은 폴더에 속하지 않는다면 IllegalArgumentException을 던진다. (공유 폴더가 루트 폴더인 경우)
- 파일이 공유받은 폴더에 속하지 않는다면 IllegalArgumentException을 던진다. (공유 폴더가 루트 폴더가 아니고 파일이 루트 폴더에 있는 경우)
- 파일이 공유받은 폴더에 속한다면 아무런 예외를 던지지 않는다.

## SearchShareService 테스트 목록
- uuid를 이용하여 Share를 찾을 수 있다.
- 일치하는 uuid의 Share가 없다면 NotFoundException을 던진다.

## PublishShareFolderService 테스트 목록
- folderId를 이용하여 Share를 생성할 수 있다.

## PublishDownloadFileLinkService 테스트 목록
- 파일 ID를 이용하여 다운로드 링크를 생성할 수 있다.

## DownloadSharedFileService 테스트 목록
- 만료되지 않은 다운로드 링크의 uuid을 이용하여 공유된 파일을 다운로드 받을 수 있다.
- 만료된 다운로드 링크의 uuid을 이용하여 공유된 파일을 다운로드 받으려하면 ExpiredLinkException을 던진다.

## DownloadFileFromSharedFolderSerivce 테스트 목록
- 공유받은 폴더 내부에 있는 파일을 누구나 다운로드 할 수 있다.

## DeleteFileToSharedFolderService 테스트 목록
- 공유받은 폴더 내부의 파일을 누구나 삭제할 수 있다.