### PR TITLE
[TEST] Folder Unit Test 작성

### DIFF
--- a/src/main/java/org/c4marathon/assignment/folder/application/service/RenameFolderService.java
+++ b/src/main/java/org/c4marathon/assignment/folder/application/service/RenameFolderService.java
@@ -2,9 +2,9 @@ package org.c4marathon.assignment.folder.application.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.c4marathon.assignment.file.application.service.component.FileFactory;
 import org.c4marathon.assignment.folder.application.port.in.RenameFolderUseCase;
 import org.c4marathon.assignment.folder.application.port.in.UpdateSummaryUseCase;
-import org.c4marathon.assignment.folder.application.port.out.FolderCommandPort;
 import org.c4marathon.assignment.folder.application.port.out.FolderQueryPort;
 import org.c4marathon.assignment.folder.domain.entity.Folder;
 import org.c4marathon.assignment.user.domain.entity.User;
@@ -21,15 +21,15 @@ public class RenameFolderService implements RenameFolderUseCase {
 
     private final FolderQueryPort folderQueryPort;
 
-    private final FolderCommandPort folderCommandPort;
-
     private final UpdatePathService updatePathService;
 
     private final UpdateSummaryUseCase updateSummaryUseCase;
 
+    private final FileFactory fileFactory;
+
     private String renameActualFolder(Folder folder, String newFolderName) {
-        File file = new File(folder.getPath());
-        File existingFolder = new File(file.getParent() + File.separator + newFolderName);
+        File file = fileFactory.createFile(folder.getPath());
+        File existingFolder = fileFactory.createFile(file.getParent() + File.separator + newFolderName);
 
         if (existingFolder.exists()) {
             throw new IllegalArgumentException("Folder already exists");

--- a/src/main/java/org/c4marathon/assignment/folder/application/service/SummaryService.java
+++ b/src/main/java/org/c4marathon/assignment/folder/application/service/SummaryService.java
@@ -43,7 +43,7 @@ public class SummaryService implements GetFolderSummaryUseCase {
             }
         }
 
-        return FolderSummaryResponseDto.of(null, (long)folders.size(), (long)files.size(), size, MAX_USER_FILE_SIZE - size, null, updatedAt);
+        return FolderSummaryResponseDto.of(null, (long)folders.size(), (long)files.size(), size, MAX_USER_FILE_SIZE != null ? MAX_USER_FILE_SIZE - size : null, null, updatedAt);
     }
 
     @Override

--- a/src/main/java/org/c4marathon/assignment/folder/application/service/WriteFolderService.java
+++ b/src/main/java/org/c4marathon/assignment/folder/application/service/WriteFolderService.java
@@ -1,6 +1,7 @@
 package org.c4marathon.assignment.folder.application.service;
 
 import lombok.RequiredArgsConstructor;
+import org.c4marathon.assignment.file.application.service.component.FileFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -9,12 +10,14 @@ import java.io.File;
 @RequiredArgsConstructor
 public class WriteFolderService {
 
+    private final FileFactory fileFactory;
+
     public String writeFolder(String email, String folderName, String parentFolderPath) {
         File file;
         if (parentFolderPath == null) {
-            file = new File("src/main/resources/upload/" + email + "/" + folderName);
+            file = fileFactory.createFile("src/main/resources/upload/" + email + "/" + folderName);
         } else {
-            file = new File(parentFolderPath + "/" + folderName);
+            file = fileFactory.createFile(parentFolderPath + "/" + folderName);
         }
 
         // 폴더가 이미 존재하는지 확인한다.

--- a/src/test/java/org/c4marathon/assignment/folder/application/service/RenameFolderServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/folder/application/service/RenameFolderServiceTest.java
@@ -1,0 +1,125 @@
+package org.c4marathon.assignment.folder.application.service;
+
+import org.c4marathon.assignment.file.application.service.component.FileFactory;
+import org.c4marathon.assignment.folder.application.port.in.UpdateSummaryUseCase;
+import org.c4marathon.assignment.folder.application.port.out.FolderQueryPort;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class RenameFolderServiceTest {
+
+    @Mock
+    private FolderSearchService folderSearchService;
+
+    @Mock
+    private FolderQueryPort folderQueryPort;
+
+    @Mock
+    private UpdatePathService updatePathService;
+
+    @Mock
+    private UpdateSummaryUseCase updateSummaryUseCase;
+
+    @Mock
+    private FileFactory fileFactory;
+
+    @InjectMocks
+    private RenameFolderService renameFolderService;
+
+    @Test
+    @DisplayName("유저는 본인이 소유한 폴더의 이름을 변경할 수 있다.")
+    void userCanRenameOwnFolder() {
+        // given
+        User user = mock(User.class);
+        Folder folder = mock(Folder.class);
+        Long folderId = 1L;
+        String newFolderName = "newFolderName";
+        when(folderQueryPort.findByUserAndName(user, newFolderName)).thenReturn(Optional.empty());
+        when(folderSearchService.findById(user, folderId)).thenReturn(folder);
+        File file = mock(File.class);
+        when(folder.getPath()).thenReturn("path");
+        when(fileFactory.createFile(folder.getPath())).thenReturn(file);
+        File existingFolder = mock(File.class);
+        when(file.getParent()).thenReturn("parent");
+        when(fileFactory.createFile("parent" + File.separator + newFolderName)).thenReturn(existingFolder);
+        when(existingFolder.exists()).thenReturn(false);
+        when(file.renameTo(existingFolder)).thenReturn(true);
+
+        // when & then
+        assertDoesNotThrow(() -> renameFolderService.renameFolder(user, folderId, newFolderName));
+    }
+
+    @Test
+    @DisplayName("이미 유저가 소유한 폴더 중 같은 이름의 폴더가 존재한다면 IllegalArgumentException을 던진다.")
+    void userCanNotRenameIfExistSameFolderName() {
+        // given
+        User user = mock(User.class);
+        Folder folder = mock(Folder.class);
+        Long folderId = 1L;
+        String newFolderName = "newFolderName";
+        when(folderQueryPort.findByUserAndName(user, newFolderName)).thenReturn(Optional.of(folder));
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> renameFolderService.renameFolder(user, folderId, newFolderName));
+    }
+
+    @Test
+    @DisplayName("파일 시스템에 이미 유저가 소유한 폴더 중 같은 이름의 폴더가 존재한다면 IllegalArgumentException을 던진다.")
+    void userCanNotRenameIfExistSameFolderNameInFileSystem() {
+        // given
+        User user = mock(User.class);
+        Folder folder = mock(Folder.class);
+        Long folderId = 1L;
+        String newFolderName = "newFolderName";
+        when(folderQueryPort.findByUserAndName(user, newFolderName)).thenReturn(Optional.empty());
+        when(folderSearchService.findById(user, folderId)).thenReturn(folder);
+        File file = mock(File.class);
+        when(folder.getPath()).thenReturn("path");
+        when(fileFactory.createFile(folder.getPath())).thenReturn(file);
+        File existingFolder = mock(File.class);
+        when(file.getParent()).thenReturn("parent");
+        when(fileFactory.createFile("parent" + File.separator + newFolderName)).thenReturn(existingFolder);
+        when(existingFolder.exists()).thenReturn(true);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> renameFolderService.renameFolder(user, folderId, newFolderName));
+    }
+
+    @Test
+    @DisplayName("파일 시스템에서 폴더의 이름을 변경하는 것에 실패했다면 IllegalArgumentException을 던진다.")
+    void userCanNotRenameIfFailToRenameAtFileSystem() {
+        // given
+        User user = mock(User.class);
+        Folder folder = mock(Folder.class);
+        Long folderId = 1L;
+        String newFolderName = "newFolderName";
+        when(folderQueryPort.findByUserAndName(user, newFolderName)).thenReturn(Optional.empty());
+        when(folderSearchService.findById(user, folderId)).thenReturn(folder);
+        File file = mock(File.class);
+        when(folder.getPath()).thenReturn("path");
+        when(fileFactory.createFile(folder.getPath())).thenReturn(file);
+        File existingFolder = mock(File.class);
+        when(file.getParent()).thenReturn("parent");
+        when(fileFactory.createFile("parent" + File.separator + newFolderName)).thenReturn(existingFolder);
+        when(existingFolder.exists()).thenReturn(false);
+        when(file.renameTo(existingFolder)).thenReturn(false);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> renameFolderService.renameFolder(user, folderId, newFolderName));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/folder/application/service/SummaryServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/folder/application/service/SummaryServiceTest.java
@@ -1,0 +1,74 @@
+package org.c4marathon.assignment.folder.application.service;
+
+import org.c4marathon.assignment.file.application.service.FileSearchService;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.folder.adapter.in.dto.FolderSummaryResponseDto;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class SummaryServiceTest {
+
+    @Mock
+    private FolderSearchService folderSearchService;
+
+    @Mock
+    private FileSearchService fileSearchService;
+
+    @InjectMocks
+    private SummaryService summaryService;
+
+    @Test
+    @DisplayName("루트 폴더의 요약 정보를 조회할 수 있다.")
+    void getFolderSummaryOfRootFolder() {
+        // given
+        User user = mock(User.class);
+        Folder targetFolder = null;
+        Folder innerFolder = Folder.of(1L, user, targetFolder, "folderName", "path", 2L, 1L, 200L);
+        File innerFile = File.of(1L, user, targetFolder, "path", "uuid", "fileName", "txt", 100L);
+
+        // mock
+        when(folderSearchService.findAllSubElementsById(user, null)).thenReturn(List.of(innerFolder));
+        when(fileSearchService.getFileListByFolder(user, null)).thenReturn(List.of(innerFile));
+
+        // when
+        FolderSummaryResponseDto folderSummary = summaryService.getFolderSummary(user, null);
+
+        // then
+        assertEquals(1, folderSummary.getTotalFolders());
+        assertEquals(1, folderSummary.getTotalFiles());
+        assertEquals(300L, folderSummary.getTotalSize());
+    }
+
+    @Test
+    @DisplayName("루트 폴더가 아닌 폴더의 요약 정보를 조회할 수 있다.")
+    void getFolderSummaryOfNotARootFolder() {
+        // given
+        User user = mock(User.class);
+        Folder targetFolder = Folder.of(1L, user, null, "folderName", "path", 1L, 1L, 300L);
+
+        // mock
+        when(folderSearchService.findById(user, 1L)).thenReturn(targetFolder);
+
+        // when
+        FolderSummaryResponseDto folderSummary = summaryService.getFolderSummary(user, targetFolder.getId());
+
+        // then
+        assertEquals(1, folderSummary.getTotalFolders());
+        assertEquals(1, folderSummary.getTotalFiles());
+        assertEquals(300L, folderSummary.getTotalSize());
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/folder/application/service/UpdatePathServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/folder/application/service/UpdatePathServiceTest.java
@@ -1,0 +1,59 @@
+package org.c4marathon.assignment.folder.application.service;
+
+import org.c4marathon.assignment.file.application.service.FileSearchService;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class UpdatePathServiceTest {
+
+    @Mock
+    private FolderSearchService folderSearchService;
+
+    @Mock
+    private FileSearchService fileSearchService;
+
+    @InjectMocks
+    private UpdatePathService updatePathService;
+
+    @Test
+    @DisplayName("부모 폴더의 변경된 이름/경로를 모든 자식 폴더와 파일에 재귀적으로 반영할 수 있다.")
+    void updatePathInternal() {
+        // given
+        User user = mock(User.class);
+        Folder folder1 = Folder.of(1L, user, null, "renamed", "src/test/resources/renamed", 1L, 0L, 1234L);
+        Folder folder2 = Folder.of(2L, user, folder1,"folder2", "src/test/resources/folder1", 0L, 1L, 1234L);
+        File file = File.of(1L, user, folder2, "src/test/resources/folder1/folder2/uuid.txt", "uuid", "fileName", "txt", 22L);
+
+        when(folderSearchService.findAllSubElementsById(user, 1L)).thenReturn(List.of(folder2));
+        when(fileSearchService.getFileListByFolder(user, 1L)).thenReturn(List.of());
+        when(folderSearchService.findAllSubElementsById(user, 2L)).thenReturn(List.of());
+        when(fileSearchService.getFileListByFolder(user, 2L)).thenReturn(List.of(file));
+
+        // when
+        updatePathService.updatePathInternal(folder1);
+
+        // then
+        verify(folderSearchService, times(1)).findAllSubElementsById(user, 1L);
+        verify(folderSearchService, times(1)).findAllSubElementsById(user, 2L);
+        verify(fileSearchService, times(1)).getFileListByFolder(user, 1L);
+        verify(fileSearchService, times(1)).getFileListByFolder(user, 2L);
+        assertEquals("src/test/resources/renamed/folder2", folder2.getPath());
+        assertEquals("src/test/resources/renamed/folder2/uuid.txt", file.getPath());
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/folder/application/service/UpdateSummaryServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/folder/application/service/UpdateSummaryServiceTest.java
@@ -1,0 +1,81 @@
+package org.c4marathon.assignment.folder.application.service;
+
+import org.c4marathon.assignment.file.application.service.FileSearchService;
+import org.c4marathon.assignment.file.domain.entity.File;
+import org.c4marathon.assignment.folder.application.port.out.FolderCommandPort;
+import org.c4marathon.assignment.folder.application.port.out.FolderQueryPort;
+import org.c4marathon.assignment.folder.domain.entity.Folder;
+import org.c4marathon.assignment.user.domain.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+class UpdateSummaryServiceTest {
+
+    @Mock
+    private FolderSearchService folderSearchService;
+
+    @Mock
+    private FolderQueryPort folderQueryPort;
+
+    @Mock
+    private FolderCommandPort folderCommandPort;
+
+    @Mock
+    private FileSearchService fileSearchService;
+
+    @InjectMocks
+    private UpdateSummaryService updateSummaryService;
+
+    @Test
+    @DisplayName("폴더 id를 이용하여 재귀적으로 폴더의 요약 정보를 업데이트 할 수 있다.")
+    void updateSummaryUsingFolderId() {
+        // given
+        User user = mock(User.class);
+        Folder folder1 = Folder.of(1L, user, null, "folder1", "src/test/resources", 1L, 0L, 1234L);
+        Folder folder2 = Folder.of(2L, user, folder1,"folder2", "src/test/resources/folder1", 0L, 1L, 1234L);
+        File file = File.of(1L, user, folder2, "src/test/resources/folder1/folder2/uuid.txt", "uuid", "fileName", "txt", 22L);
+        LocalDateTime updateAt = LocalDateTime.of(2021, 1, 1, 0, 0);
+
+        when(folderQueryPort.findByUserAndId(user, 1L)).thenReturn(Optional.of(folder1));
+        when(folderQueryPort.findByUserAndId(user, 2L)).thenReturn(Optional.of(folder2));
+        when(folderSearchService.findAllSubElementsById(user, 1L)).thenReturn(List.of(folder2));
+        when(folderSearchService.findAllSubElementsById(user, 2L)).thenReturn(List.of());
+        when(fileSearchService.getFileListByFolder(user, 2L)).thenReturn(List.of(file));
+
+        // when
+        updateSummaryService.updateSummary(user, 2L, updateAt);
+
+        // then
+        assertEquals(22L, folder2.getFolderSize());
+        assertEquals(22L, folder1.getFolderSize());
+        assertEquals(folder2.getUpdatedAt(), updateAt);
+        assertEquals(folder1.getUpdatedAt(), updateAt);
+    }
+
+    @Test
+    @DisplayName("폴더 id에 해당하는 폴더가 존재하지 않는다면 요약 정보를 업데이트하지 않는다.")
+    void doNotUpdateSummaryIfFolderDoesNotExist() {
+        // given
+        User user = mock(User.class);
+        when(folderQueryPort.findByUserAndId(user, 1L)).thenReturn(Optional.empty());
+
+        // when
+        updateSummaryService.updateSummary(user, 1L, LocalDateTime.now());
+
+        // then
+        verify(folderSearchService, times(0)).findAllSubElementsById(any(), any());
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/folder/application/service/WriteFolderServiceTest.java
+++ b/src/test/java/org/c4marathon/assignment/folder/application/service/WriteFolderServiceTest.java
@@ -1,0 +1,106 @@
+package org.c4marathon.assignment.folder.application.service;
+
+import org.c4marathon.assignment.file.application.service.component.FileFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(SpringExtension.class)
+class WriteFolderServiceTest {
+
+    @Mock
+    private FileFactory fileFactory;
+
+    @InjectMocks
+    private WriteFolderService writeFolderService;
+
+    @Test
+    @DisplayName("sub directory를 포함한 폴더 계층을 생성할 수 있다. (부모 디렉토리가 루트 디렉토리인 경우)")
+    void writeFolderWithSubDirectoryForRootParentDirectory() {
+        // given
+        String email = "test@example.com";
+        String folderName = "folderName";
+        String parentFolderPath = null;
+
+        // mock
+        File file = mock(File.class);
+        when(fileFactory.createFile("src/main/resources/upload/" + email + "/" + folderName)).thenReturn(file);
+        when(file.exists()).thenReturn(false);
+        when(file.mkdirs()).thenReturn(true);
+        when(file.getPath()).thenReturn("src/main/resources/upload/" + email + "/" + folderName);
+
+        // when
+        String result = writeFolderService.writeFolder(email, folderName, parentFolderPath);
+
+        // then
+        assertEquals("src/main/resources/upload/" + email + "/" + folderName, result);
+    }
+
+    @Test
+    @DisplayName("sub directory를 포함한 폴더 계층을 생성할 수 있다. (부모 디렉토리가 루트 디렉토리가 아닌 경우)")
+    void writeFolderWithSubDirectory() {
+        // given
+        String email = "test@example.com";
+        String folderName = "folderName";
+        String parentFolderPath = "src/main/resources/upload/" + email + "/parentFolder";
+
+        // mock
+        File file = mock(File.class);
+        when(fileFactory.createFile(parentFolderPath + "/" + folderName)).thenReturn(file);
+        when(file.exists()).thenReturn(false);
+        when(file.mkdirs()).thenReturn(true);
+        when(file.getPath()).thenReturn(parentFolderPath + "/" + folderName);
+
+        // when
+        String result = writeFolderService.writeFolder(email, folderName, parentFolderPath);
+
+        // then
+        assertEquals(parentFolderPath + "/" + folderName, result);
+    }
+
+    @Test
+    @DisplayName("폴더가 이미 존재한다면 IllegalArgumentException을 던진다.")
+    void failWhenFolderAlreadyExist() {
+        // given
+        String email = "test@example.com";
+        String folderName = "folderName";
+        String parentFolderPath = "src/main/resources/upload/" + email + "/parentFolder";
+
+        // mock
+        File file = mock(File.class);
+        when(fileFactory.createFile(parentFolderPath + "/" + folderName)).thenReturn(file);
+        when(file.exists()).thenReturn(true);
+        when(file.mkdirs()).thenReturn(true);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> writeFolderService.writeFolder(email, folderName, parentFolderPath));
+    }
+
+    @Test
+    @DisplayName("폴더 생성에 실패한다면 IllegalArgumentException을 던진다.")
+    void failToMkdirs() {
+        // given
+        String email = "test@example.com";
+        String folderName = "folderName";
+        String parentFolderPath = "src/main/resources/upload/" + email + "/parentFolder";
+
+        // mock
+        File file = mock(File.class);
+        when(fileFactory.createFile(parentFolderPath + "/" + folderName)).thenReturn(file);
+        when(file.exists()).thenReturn(false);
+        when(file.mkdirs()).thenReturn(false);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> writeFolderService.writeFolder(email, folderName, parentFolderPath));
+    }
+
+}

--- a/src/test/java/org/c4marathon/assignment/folder/domain/entity/FolderTest.java
+++ b/src/test/java/org/c4marathon/assignment/folder/domain/entity/FolderTest.java
@@ -1,0 +1,127 @@
+package org.c4marathon.assignment.folder.domain.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FolderTest {
+
+    @Test
+    @DisplayName("폴더의 이름과 경로를 변경할 수 있다.")
+    void rename() {
+        // given
+        Folder folder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 0L);
+        String newFolderName = "newFolderName";
+        String newPath = "newPath";
+
+        // when
+        folder.rename(newFolderName, newPath);
+
+        // then
+        assertThat(folder.getFolderName()).isEqualTo(newFolderName);
+        assertThat(folder.getPath()).isEqualTo(newPath);
+    }
+
+    @Test
+    @DisplayName("부모 폴더로 폴더를 옮기고, 폴더의 path를 업데이트할 수 있다.")
+    void updatePathToParentFolder() {
+        // given
+        Folder oldFolder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 0L);
+        Folder parentFolder = Folder.of(1L, null, null, "parentFolder", "parentFolderPath", 0L, 0L, 0L);
+        String parentPath = "update/parent/folder/path";
+
+        // when
+        oldFolder.updatePath(parentFolder, parentPath);
+
+        // then
+        assertThat(oldFolder.getParentFolder()).isEqualTo(parentFolder);
+        assertThat(oldFolder.getPath()).isEqualTo(parentPath + "/" + oldFolder.getFolderName());
+    }
+
+    @Test
+    @DisplayName("부모 폴더로 폴더를 옮기고, 폴더의 path를 업데이트할 수 있다. (부모 폴더가 Root 폴더인 경우)")
+    void updatePathToRootParentFolder() {
+        // given
+        Folder oldFolder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 0L);
+        Folder parentFolder = null;
+        String parentPath = "update/parent/folder/path";
+
+        // when
+        oldFolder.updatePath(parentFolder, parentPath);
+
+        // then
+        assertThat(oldFolder.getParentFolder()).isEqualTo(parentFolder);
+        assertThat(oldFolder.getPath()).isEqualTo(parentPath + "/" + oldFolder.getFolderName());
+    }
+
+    @Test
+    @DisplayName("count만큼 폴더의 innerFolderCount를 업데이트할 수 있다.")
+    void updateInnerFolderCount() {
+        // given
+        Folder folder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 0L);
+        Long count = 10L;
+
+        // when
+        folder.updateInnerFolderCount(count);
+
+        // then
+        assertThat(folder.getInnerFolderCount()).isEqualTo(count);
+    }
+
+    @Test
+    @DisplayName("count만큼 폴더의 innerFileCount를 업데이트할 수 있다.")
+    void updateInnerFileCount() {
+        // given
+        Folder folder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 0L);
+        Long count = 10L;
+
+        // when
+        folder.updateInnerFileCount(count);
+
+        // then
+        assertThat(folder.getInnerFileCount()).isEqualTo(count);
+    }
+
+    @Test
+    @DisplayName("size만큼 폴더의 folderSize를 업데이트할 수 있다.")
+    void updateFolderSize() {
+        // given
+        Folder folder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 10L);
+        Long size = 10L;
+
+        // when
+        folder.updateFolderSize(size);
+
+        // then
+        assertThat(folder.getFolderSize()).isEqualTo(size);
+    }
+
+    @Test
+    @DisplayName("size만큼 폴더의 folderSize를 더할 수 있다.")
+    void addFolderSize() {
+        // given
+        Folder folder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 10L);
+        Long size = 10L;
+
+        // when
+        folder.addFolderSize(size);
+
+        // then
+        assertThat(folder.getFolderSize()).isEqualTo(20L);
+    }
+
+    @Test
+    @DisplayName("폴더의 folderSize를 0으로 초기화할 수 있다.")
+    void initializeFolderSize() {
+        // given
+        Folder folder = Folder.of(1L, null, null, "oldFolderName", "oldPath", 0L, 0L, 10L);
+
+        // when
+        folder.initializeFolderSize();
+
+        // then
+        assertThat(folder.getFolderSize()).isEqualTo(0L);
+    }
+
+}


### PR DESCRIPTION
## Folder 작성 테스트 목록
- 폴더의 이름과 경로를 변경할 수 있다.
- 부모 폴더로 폴더를 옮기고, 폴더의 path를 업데이트할 수 있다.
- 부모 폴더로 폴더를 옮기고, 폴더의 path를 업데이트할 수 있다. (부모 폴더가 Root 폴더인 경우)
- count만큼 폴더의 innerFolderCount를 업데이트할 수 있다.
- count만큼 폴더의 innerFileCount를 업데이트할 수 있다.
- size만큼 폴더의 folderSize를 업데이트할 수 있다.
- size만큼 폴더의 folderSize를 더할 수 있다.
- 폴더의 folderSize를 0으로 초기화할 수 있다.

## WriteFolderService 작성 테스트 목록
- sub directory를 포함한 폴더 계층을 생성할 수 있다. (부모 디렉토리가 루트 디렉토리인 경우)
- sub directory를 포함한 폴더 계층을 생성할 수 있다. (부모 디렉토리가 루트 디렉토리가 아닌 경우)
- 폴더가 이미 존재한다면 IllegalArgumentException을 던진다.
- 폴더 생성에 실패한다면 IllegalArgumentException을 던진다.

## UpdateSummaryService 작성 테스트 목록
- 폴더 id를 이용하여 재귀적으로 폴더의 요약 정보를 업데이트 할 수 있다.
- 폴더 id에 해당하는 폴더가 존재하지 않는다면 요약 정보를 업데이트하지 않는다.

## UpdatePathService 작성 테스트 목록
- 부모 폴더의 변경된 이름/경로를 모든 자식 폴더와 파일에 재귀적으로 반영할 수 있다.

## SummaryService 작성 테스트 목록
- 루트 폴더의 요약 정보를 조회할 수 있다.
- 루트 폴더가 아닌 폴더의 요약 정보를 조회할 수 있다.

## RenameFolderService 작성 테스트 목록
- 유저는 본인이 소유한 폴더의 이름을 변경할 수 있다.
- 이미 유저가 소유한 폴더 중 같은 이름의 폴더가 존재한다면 IllegalArgumentException을 던진다.
- 파일 시스템에 이미 유저가 소유한 폴더 중 같은 이름의 폴더가 존재한다면 IllegalArgumentException을 던진다.
- 파일 시스템에서 폴더의 이름을 변경하는 것에 실패했다면 IllegalArgumentException을 던진다.



